### PR TITLE
Update CMake minimum version and project version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,6 @@
-cmake_minimum_required(VERSION 2.6)
-cmake_policy(SET CMP0048 "NEW")
+cmake_minimum_required(VERSION 3.16)
 
-project(delabella LANGUAGES CXX VERSION 1.0)
+project(delabella LANGUAGES CXX VERSION 2.0)
 
 add_library(${PROJECT_NAME} STATIC ${PROJECT_SOURCE_DIR}/delabella.cpp)
 


### PR DESCRIPTION
Updated CMake minimum version to 3.16 due to fedora requirements of 3.5 starting in fedora 44.  Project version was also updated.