### PR TITLE
Use GnuInstallDirs to provide reliable install locations across platforms.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,6 @@
-cmake_minimum_required(VERSION 2.6)
-cmake_policy(SET CMP0048 "NEW")
+cmake_minimum_required(VERSION 3.16)
 
-project(delabella LANGUAGES CXX VERSION 1.0)
+project(delabella LANGUAGES CXX VERSION 2.0)
 
 add_library(${PROJECT_NAME} STATIC ${PROJECT_SOURCE_DIR}/delabella.cpp)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,11 +2,19 @@ cmake_minimum_required(VERSION 3.16)
 
 project(delabella LANGUAGES CXX VERSION 2.0)
 
-add_library(${PROJECT_NAME} STATIC ${PROJECT_SOURCE_DIR}/delabella.cpp)
+include(GNUInstallDirs)
+
+add_library(${PROJECT_NAME} ${PROJECT_SOURCE_DIR}/delabella.cpp)
 
 target_include_directories(${PROJECT_NAME} PUBLIC ${PROJECT_SOURCE_DIR})
 
+set_target_properties(${PROJECT_NAME} PROPERTIES
+    VERSION ${PROJECT_VERSION}
+    SOVERSION ${PROJECT_VERSION_MAJOR})
+
 add_library(delabella::delabella ALIAS delabella)
 
-install(FILES ${PROJECT_SOURCE_DIR}/delabella.h DESTINATION include)
-install(TARGETS ${PROJECT_NAME} ARCHIVE DESTINATION lib)
+install(FILES ${PROJECT_SOURCE_DIR}/delabella.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+install(TARGETS ${PROJECT_NAME}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})


### PR DESCRIPTION
Requires the update to cmake, but can use 3.5 if necessary.

This should behave identically to the original in the case of windows install.  This change provides necessary functionality for a repo-based rpm build on Fedora, which is currently provided by a patch file.