### PR TITLE
added ctime dependency

### DIFF
--- a/delabella-sdl2.cpp
+++ b/delabella-sdl2.cpp
@@ -37,6 +37,7 @@ Copyright (C) 2018-2022 GUMIX - Marcin Sokalski
 #include <stdio.h>
 #include <stdarg.h>
 #include <assert.h>
+#include <ctime>
 
 #include <vector>
 


### PR DESCRIPTION
CLOCK_MONOTONIC is called within the program, but ctime is not declared as a dependency.